### PR TITLE
Add nrepl/bencode dependency for JVM projects

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,3 @@
-{:paths ["src"]}
+{:deps
+ {nrepl/bencode {:mvn/version "1.1.0"}}
+ :paths ["src"]}


### PR DESCRIPTION
When using JVM/Clojure to load the nrepl it fails as it cannot find `nrepl/bencode`, this fixes it for me.